### PR TITLE
Add bronze to bronze block to the beacon_base_blocks tag and bronze ingot to the beacon_payment_items tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/beacon_base_blocks.json
+++ b/common/src/main/resources/data/minecraft/tags/block/beacon_base_blocks.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "mobs_of_mythology:bronze_block"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/beacon_payment_items.json
+++ b/common/src/main/resources/data/minecraft/tags/item/beacon_payment_items.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "mobs_of_mythology:bronze_ingot"
+  ]
+}


### PR DESCRIPTION
This allows bronze blocks to be used as beacon base and bronze ingot to be used to activate beacon. I think this does make sense for consistency reasons. 
I hope it's fine that I just submitted a PR without opening an issue first since it's just a small change.